### PR TITLE
Amend {qs} write minimum time

### DIFF
--- a/Posit Infrastructure/Recommended Data Flow with Stats.md
+++ b/Posit Infrastructure/Recommended Data Flow with Stats.md
@@ -61,7 +61,7 @@ Writing an extract of 1 million rows from the SMR01 dataset to the Stats server.
 |---|---|---|---|---|
 |{arrow}|parquet|ZStandard|39.57|39.77|
 |{arrow}|parquet|Snappy|46.53|46.59|
-|{qs}|qs|ZStandard|4.69|46.92|
+|{qs}|qs|ZStandard|46.9|46.92|
 |{vroom}|csv|ZStandard|72|73.2|
 |{vroom}|csv|Gzip|150|150|
 |{readr}|csv|Uncompressed|174|174|


### PR DESCRIPTION
# Pull Request Details

Amend minimum time reported to write 1 million rows from the SMR01 dataset to the Stats server using the {qs} package as the figure is incorrect.

**Issue Number**: #11
https://github.com/Public-Health-Scotland/technical-docs/issues/11

**Type**: Bug

## Description of the Change

See pull request details above.

### Verification Process

I carried out the original analysis for this guidance.

### Additional Work Required

None

## Release Notes

N/A
