### PR TITLE
Update FAQs.md with section on installing {gt}

### DIFF
--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -18,6 +18,12 @@ If you are working remotely, yes: ensure that when you login to Windows that you
 
 ### Installing Packages
 
+#### How do I install the `{gt}` package?
+
+Versions of the [`{gt}`](https://gt.rstudio.com/) package, up to and including v0.5.0, use [PhantomJS](https://phantomjs.org/) (a scriptable headless browser) to take screenshots of tables produced by `{gt}`.  Newer versions ot `{gt}` require a Chromium-based browser which is not yet configured correctly in the Posit Workbench environment.
+
+Instructions and a script for installing and testing v0.5.0 of the `{gt}` package and all of its dependencies can be found in the [posit-workbench-install-gt](https://github.com/Public-Health-Scotland/posit-workbench-install-gt) repo.
+
 #### How do I install the `{hablar}` package?
 
 The `{hablar}` package cannot be installed as a pre-compiled binary; attempting this gives an error.  Therefore, you need to force R to install the source version by specifying the URL for the source version of packages on Package Manager.  However, `{hablar}`'s dependencies can be installed as binaries first.


### PR DESCRIPTION
# Pull Request Details

Provides details of why the latest version of the `{gt}` package will not install and work as expected on Posit Workbench and links to the [posit-workbench-install-gt](https://github.com/Public-Health-Scotland/posit-workbench-install-gt) repo that contains detailed installation instructions for v0.5.0 of `{gt}` and all of its dependencies.

**Issue Number**: #13

**Type**: Documentation

## Description of the Change

See pull request details above.

### Verification Process

John Wood and I have tested that the installation script works correctly.

### Additional Work Required

None.

## Release Notes

Update FAQs with section on installing the `{gt}` package
