### PR TITLE
Exclude base packages from geo_deps_bin

### DIFF
--- a/Infrastructure/How to Install and Use Geospatial R Packages.md
+++ b/Infrastructure/How to Install and Use Geospatial R Packages.md
@@ -91,8 +91,8 @@ Many of the dependencies of the geospatial R packages can be installed as binari
 # Get list of geospatial package dependencies that can be installed as binaries
 geo_deps_bin <- sort(setdiff(geo_deps, geo_pkgs))
 
-# Remove available (base) packages
-geo_deps_bin <- geo_deps_bin[!(geo_deps_bin %in% rownames(available.packages()))]
+# Remove packages that are already installed from the list of geospatial package dependencies
+geo_deps_bin <- sort(setdiff(geo_deps_bin, as.data.frame(installed.packages())$Package))
 
 # Install these as binaries
 install.packages(pkgs = geo_deps_bin,

--- a/Infrastructure/How to Install and Use Geospatial R Packages.md
+++ b/Infrastructure/How to Install and Use Geospatial R Packages.md
@@ -91,6 +91,9 @@ Many of the dependencies of the geospatial R packages can be installed as binari
 # Get list of geospatial package dependencies that can be installed as binaries
 geo_deps_bin <- sort(setdiff(geo_deps, geo_pkgs))
 
+# Remove available (base) packages
+geo_deps_bin <- geo_deps_bin[!(geo_deps_bin %in% rownames(available.packages()))]
+
 # Install these as binaries
 install.packages(pkgs = geo_deps_bin,
                  repos = c("https://ppm.publichealthscotland.org/all-r/__linux__/centos7/latest"),


### PR DESCRIPTION
# Pull Request Details

**Type**: Bug 

## Description of the Change

Added line to remove "available" packages. This should only affect "base" packages which were causing the system to loop as these were already "loaded". I don't think these should be listed as dependencies but impacted were: graphics_package, grDevices, grid, methods, splines, stats, tools, and utils.

### Verification Process

Used to install geospatial on own session. 
