### PR TITLE
Add the question 'Why does the `{rmapshaper}` package not install?'

### DIFF
--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -63,6 +63,10 @@ install.packages("phsmethods")
 
 Some packages, e.g. `{xlsx}`, `{XLconnect}`, depend on an installation of [Java](https://en.wikipedia.org/wiki/Java_(software_platform)) in order to work.  There are no current or future plans to support Java on Posit Workbench.  Alternative packages such as `{openxlsx}` that do not rely on Java should be used instead.
 
+#### Why does the `{rmapshaper}` package not install?
+
+`{rmapshaper}` has the dependencies `{V8}` and `{geojsonio}`, neither of which can be installed successfully on the CentOS 7 container image that Posit Workbench runs in. As these dependencies cannot be installed, {rmapshaper} also fails to install. As it stands, there is no immediate solution to resolve this.
+
 ### Projects
 
 #### What is a project (in Posit Workbench)?


### PR DESCRIPTION
# Pull Request Details

**Issue Number**: 25

**Type**: Bug / Feature / Documentation / Other (Delete as appropriate)

## Description of the Change

Updated the FAQs to include the question 'Why does the `{rmapshaper}` package not install?' and provide an appropriate answer.

### Verification Process

The answer is based on advice provided by NSS DaS and Jumping Rivers.

### Additional Work Required

None.

## Release Notes

Not applicable.
