### PR TITLE
feat: add reviewers to the Pull Request Section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,10 +99,11 @@ The process described here has several goals:
 * Engage the community in working toward the best possible documentation
 * Enable a sustainable system for maintainers to review contributions
 
-Please follow these steps to have your contribution considered by the maintainers:
+Please follow these steps to have your contribution considered by the maintainers / reviewers (the [Data Science team](mailto:phs.datascience@phs.scot)):
 
 1. Follow all instructions in the template, this will auto-populate when you open a Pull Request.
 2. Follow the [style guides](#style-guides)
+3. Send an email to the [Data Science team](mailto:phs.datascience@phs.scot) to make them aware of your contribution.
 
 While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 


### PR DESCRIPTION
Currently, it is not clear who the reviewers are for a pull request.
I supposed sending an email to the reviewers was a required step to make them aware.