### PR TITLE
Fix link formatting in the R Style Guide

### DIFF
--- a/R/R Style Guide.md
+++ b/R/R Style Guide.md
@@ -1,8 +1,8 @@
 # R Style Guide
 
-This document is a coding style guide for using R within PHS. It is designed to allow enough flexibility for working on different projects, while maintaining consistency across the organisation and ensuring that code can be easily read and shared. As a foundation, the [Tidyverse style guide](https://style.tidyverse.org/) is used, with some additional guidance on how to use R in a way that is consistent with the rest of PHS.
+This document is a coding style guide for using R within PHS. It is designed to allow enough flexibility for working on different projects while maintaining consistency across the organisation and ensuring that code can be easily read and shared. As a foundation, the [Tidyverse style guide](https://style.tidyverse.org/) is used, with some additional guidance on how to use R in a way that is consistent with the rest of PHS.
 
-*Adapted from guidance orginally written by Anna Price and David Caldwell, Public Health Scotland.*
+*Adapted from guidance originally written by Anna Price and David Caldwell, Public Health Scotland.*
 
 ***
 
@@ -39,7 +39,7 @@ RStudio has a shortcut for creating sections - either press `ctrl`+`shift`+`R` o
 
 ## 3 - Structure
 
-The exact structure of a script should be decided by the analyst writing the code and should be appropriate for the analyses being carried out. However, as a general rule there should be a housekeeping section at the start - this should be the only section of the script which requires manual changes for future updates and includes:
+The exact structure of a script should be decided by the analyst writing the code and should be appropriate for the analyses being carried out. However, as a general rule, there should be a housekeeping section at the start - this should be the only section of the script which requires manual changes for future updates and includes:
 
 * loading packages
 * setting filepaths and extract dates
@@ -47,20 +47,20 @@ The exact structure of a script should be decided by the analyst writing the cod
 * setting plot parameter
 * specifying codes (e.g. ICD-10 codes) once for generic calculations such as incidence rates
 
-If the script is part of a project with multiple scripts, it is instead recommended that code for all scripts that requires manual changes for future updates be kept in a separate script that is then sourced in using the `source()` function. This minimises the number of edits required which lowers the risk of error. If there is a conflict, e.g., two scripts need a different `start_date` variable, both should be defined with clear naming.
+If the script is part of a project with multiple scripts, it is instead recommended that code for all scripts that require manual changes for future updates be kept in a separate script that is then sourced using the `source()` function. This minimises the number of edits required which lowers the risk of error. If there is a conflict, e.g., two scripts need a different `start_date` variable, both should be defined with clear naming.
 
 Finally, it is useful to mark the end of a script, e.g., `### END OF SCRIPT ###`
 
 ## 4 - Commenting
 
-Scripts should be appropriately commented. Comments are used to explain your code to others who may have to interact with the code. They should be succinct, so that the script is readable, but detailed enough so that another analyst could understand, run and edit it.
+Scripts should be appropriately commented. Comments are used to explain your code to others who may have to interact with the code. They should be succinct so that the script is readable but detailed enough so that another analyst could understand, run and edit it.
 
 Comments can also be used for instruction and if so this should be clearly marked e.g.
 `# TO DO - Needs re-written to reduce looping`
 
 Use one hash to comment out annotations.
 
-It is also important the code-readibility shouldn't rely on comments. If the code is not clear enough to be understood without comments, consider rewritting.
+It is also important that code-readability shouldn't rely on comments. If the code is not clear enough to be understood without comments, consider rewriting.
 
 ## 5 - Functions
 
@@ -105,10 +105,10 @@ We recommend following Hadley Wickham's [tidyverse style guide](http://style.tid
 * curly brackets
 * assignment
 
-To help clean up your code, the `{[lintr](https://lintr.r-lib.org/)}` package provides an automated check for compliance with the tidyverse style guide and warns you about potential mistakes or problems.
+To help clean up your code, the [`{lintr}`](https://lintr.r-lib.org/) package provides an automated check for compliance with the tidyverse style guide and warns you about potential mistakes or problems.
 
-Even better the `{[styler](https://styler.r-lib.org/)}` package can automatically reformat code (making only cosmetic changes) so that you can always have consistent well formatted code with minimal effort.
+Even better the [`{styler}`](https://styler.r-lib.org/) package can automatically reformat code (making only cosmetic changes) so that you can always have consistent well formatted code with minimal effort.
 
 ## 10 - R User Group
 
-The PHS R User Group shares good practice amoungst the user community and is a useful support system for users requiring assistance. You can join the [PHS R User Group on Teams](https://teams.microsoft.com/l/team/19%3ae9f55a12b7d94ef49877ff455a07f035%40thread.tacv2/conversations?groupId=ec4250f9-b70a-4f32-9372-a232ccb4f713&tenantId=10efe0bd-a030-4bca-809c-b5e6745e499a) for news, events, and technical queries.
+The PHS R User Group shares good practice amongst the user community and is a useful support system for users requiring assistance. You can join the [PHS R User Group on Teams](https://teams.microsoft.com/l/team/19%3ae9f55a12b7d94ef49877ff455a07f035%40thread.tacv2/conversations?groupId=ec4250f9-b70a-4f32-9372-a232ccb4f713&tenantId=10efe0bd-a030-4bca-809c-b5e6745e499a) for news, events, and technical queries.


### PR DESCRIPTION
Also, fix some typos. The link formatting was introduced in #16, the typos were preexisting but I noticed them as I was editing in the browser, and I have a spelling/grammar checker 😉
