### PR TITLE
Update How to Install and Use Geospatial R Packages.md

### DIFF
--- a/Posit Infrastructure/How to Install and Use Geospatial R Packages.md
+++ b/Posit Infrastructure/How to Install and Use Geospatial R Packages.md
@@ -79,7 +79,7 @@ remove.packages("parallelly")
 # Install the 'parallelly' package
 install.packages("parallelly")
 
-# Identify number of CPUs available
+# Identify the number of CPUs available
 ncpus <- as.numeric(parallelly::availableCores())
 ```
 
@@ -124,10 +124,11 @@ install.packages("sf",
                  Ncpus = ncpus)
 
 # Install the {terra} package
-install.packages("terra",
+install.packages("https://ppm.publichealthscotland.org/all-r/latest/src/contrib/Archive/terra/terra_1.7-29.tar.gz",
+                 repos = NULL,
+                 type = "source",
                  configure.args = geo_config_args,
                  INSTALL_opts = "--no-test-load",
-                 repos = c("https://ppm.publichealthscotland.org/all-r/latest"),
                  Ncpus = ncpus)
 
 # Install the {sp} package
@@ -161,7 +162,7 @@ install.packages("leaflet",
 
 ## Loading geospatial R packages
 
-Before loading any geospatial R packages, please ensure that you have run the code in [Setting environment variables](#Setting-environment-variables).  You **must** do this in every session that you open before loading geospatial R packages.
+Before you load any geospatial R packages, please make sure you run the code in [Setting environment variables](#Setting-environment-variables).  You **must** do this in every session you open before loading geospatial R packages.
 
 You must also ensure that you loaded the geospatial libraries so that R can see them:
 
@@ -170,9 +171,9 @@ dyn.load("/usr/gdal34/lib/libgdal.so")
 dyn.load("/usr/geos310/lib64/libgeos_c.so", local = FALSE)
 ```
 
-Again the above R code **must** be run in every session that you open before loading geospatial R packages.
+Again the above R code **must** be run in every session you open before loading geospatial R packages.
 
-Then, loading geospatial R packages can be loaded in the same way as normal with calls to the `library()` function e.g.
+Then, geospatial R packages can be loaded in the same way as normal with calls to the `library()` function e.g.
 
 ```r
 library(terra)


### PR DESCRIPTION
`{terra}` needs to be pinned to an older version, as the latest now fails to install as it requires C++17. - There's been various comments in Teams about this but I saw a [comment from Niel Perkins](https://teams.microsoft.com/l/message/19:9620ef6cf8234d50a0f95caba65a3edf@thread.tacv2/1692027487880?tenantId=10efe0bd-a030-4bca-809c-b5e6745e499a&groupId=ec4250f9-b70a-4f32-9372-a232ccb4f713&parentMessageId=1687355570162&teamName=PHS%20Data%20and%20Intelligence%20Forum&channelName=Posit%20Technical%20Queries&createdTime=1692027487880&allowXTenantAccess=false) - 

I am slightly confused as to why `{raster}` is pinned to 2.5-8 as `{leaflet}` now depends on `{raster}` >= 3.6.3, so this is installed/updated automatically when installing that but everything works fine, implying it didn't need to be pinned to the older version on the 'initial' install.

I also fixed some grammar.