### PR TITLE
Update Overnight Sessions.md

### DIFF
--- a/Posit Infrastructure/Overnight Sessions.md
+++ b/Posit Infrastructure/Overnight Sessions.md
@@ -27,11 +27,3 @@ A Posit Workbench session that a user would like to continue running past 9pm mu
 4. Amend any other settings as required in the "New Session" dialog box, and click the blue "Start Session" button.  The session will start as normal.
 
 **Important Note:** If you open a project from within a session started by following the steps above, the process of opening that project will start another session and close your "NIGHT" session.  As such, the session that the project opens in will no longer have "NIGHT" at the start of its name, and it will be closed at 9pm by the automated process.
-
-## Process to open a "NIGHT" project
-
-1. Firstly, ensure that the project's .Rproj file and root directory (i.e. the directory that contains the .Rproj file) both share the same name, and that the name has the word "NIGHT" at the start, e.g. "/conf/linkage/output/NIGHT my project/NIGHT my project.Rproj"
-
-2. Follow the steps outlined at [How to Login to Posit Workbench](How%20to%20Login%20to%20Posit%20Workbench.md) to log in to Posit Workbench and start a new session.
-
-3. Follow steps outlined in [FAQs - Projects](FAQs.md#projects) to open the project.


### PR DESCRIPTION
# Pull Request Details

Including the word "NIGHT" in a project's name is not required to override the automated process that closes sessions in Posit Workbench at 9pm every evening.

**Issue Number**: closes #69 

**Type**: Bug

## Description of the Change

This pull request removes the section entitled 'Process to open a "NIGHT" project' from 'Posit Infrastructure/Overnight Sessions.md'

### Verification Process

@r6lm has investigated and realised that when you follow the instructions on opening projects which is currently in the guidance of the NIGHT tag, you still have to choose the name of the session. Therefore, it is there where you can set the NIGHT tag on the name. Hence, there is no need of the NIGHT tag on the name of the Project

### Additional Work Required

None

## Release Notes

Corrects the guidance on overriding the automated process that closes sessions in Posit Workbench at 9pm every evening.
