### PR TITLE
71 faq guidance on preventing shiny apps from timing out when run locally

### DIFF
--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -151,6 +151,19 @@ Doing so may result in Posit Workbench crashing or certain error messages such a
 
 This is a [known issue](https://github.com/rstudio/rstudio/issues/11914) in older versions of Posit Workbench which will likely be fixed when the Posit Workbench environment is next updated.
 
+### Troubleshooting packages
+
+#### How do I stop `{shiny}` apps timing out so quickly?
+
+If your `{shiny}` apps are timing out after just a few seconds when run locally, you can add the workaround code below to the app's server.R script to prevent this:
+
+```{r}
+auto_invalidate <- reactiveTimer(10000)
+
+observe({
+    auto_invalidate()
+    cat(".")})
+```
 ## Posit Package Manager
 
 * [Accessing Posit Package Manager](#accessing-posit-package-manager)
@@ -172,17 +185,3 @@ Microsoft Edge is the recommended, and supported, web browser for accessing Posi
 #### What web browser should I use for Posit Connect?
 
 Microsoft Edge is the recommended, and supported, web browser for accessing Posit Connect.
-
-### Troubleshooting packages
-
-#### How do I stop `{shiny}` apps timing out so quickly?
-
-If your `{shiny}` apps are timing out after just a few seconds when run locally, you can add the workaround code below to the app's server.R script to prevent this:
-
-```{r}
-auto_invalidate <- reactiveTimer(10000)
-
-observe({
-    auto_invalidate()
-    cat(".")})
-```

--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -21,6 +21,8 @@ This document aims to answer frequently asked questions from users in relation t
 * [Projects](#projects)
   * [What is a project (in Posit Workbench)?](#what-is-a-project-in-posit-workbench)
   * [How do I open or switch to another project?](#how-do-i-open-or-switch-to-another-project)
+* [Troubleshooting packages](#troubleshooting-packages)
+  * [How do I stop `{shiny}` apps timing out so quickly?](#how-do-i-stop-shiny-apps-timing-out-so-quickly)
 
 ### Accessing Posit Workbench
 
@@ -170,3 +172,16 @@ Microsoft Edge is the recommended, and supported, web browser for accessing Posi
 #### What web browser should I use for Posit Connect?
 
 Microsoft Edge is the recommended, and supported, web browser for accessing Posit Connect.
+
+### Troubleshooting packages
+
+#### How do I stop `{shiny}` apps timing out so quickly?
+
+If your `{shiny}` apps are timing out after just a few seconds when run locally, you can add the workaround code below to the app's server.R script to prevent this:
+
+```{r}{auto_invalidate <- reactiveTimer(10000)
+  observe({
+    auto_invalidate()
+    cat(".")
+  })
+}```

--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -179,9 +179,10 @@ Microsoft Edge is the recommended, and supported, web browser for accessing Posi
 
 If your `{shiny}` apps are timing out after just a few seconds when run locally, you can add the workaround code below to the app's server.R script to prevent this:
 
-```{r}{auto_invalidate <- reactiveTimer(10000)
-  observe({
+```{r}
+auto_invalidate <- reactiveTimer(10000)
+
+observe({
     auto_invalidate()
-    cat(".")
-  })
-}```
+    cat(".")})
+```


### PR DESCRIPTION
# Pull Request Details

**Issue Number**: 71

https://github.com/Public-Health-Scotland/technical-docs/issues/71

**Type**: Documentation

## Description of the Change

Updated guidance added to FAQs on shiny apps timing out. Closes #71 

### Verification Process

Code chunk provided is a known and tested workaround for this issue that has been in circulation for some time already.

### Additional Work Required

N/A

## Release Notes

Updated guidance added to FAQs on shiny apps timing out.