### PR TITLE
Update FAQs to add guidance on 'failed to lock directory' errors

### DIFF
--- a/Posit Infrastructure/FAQs.md
+++ b/Posit Infrastructure/FAQs.md
@@ -19,6 +19,7 @@ This document aims to answer frequently asked questions from users in relation t
   * [How do I install the `{phsmethods}` package?](#how-do-i-install-the-phsmethods-package)
   * [How do I install the `{ranger}` package?](#how-do-i-install-the-ranger-package)
   * [What do I do if a package requires `{rJava}`?](#what-do-i-do-if-a-package-requires-rjava)
+  * [What should I do if I encounter a 'failed to lock directory' error?](#what-should-i-do-if-i-encounter-a-failed-to-lock-directory-error)
   * [Why does the `{rmapshaper}` package not install?](#why-does-the-rmapshaper-package-not-install)
 * [Projects](#projects)
   * [What is a project (in Posit Workbench)?](#what-is-a-project-in-posit-workbench)
@@ -111,6 +112,12 @@ install.packages("ranger")
 
 Some packages, e.g. `{xlsx}`, `{XLconnect}`, depend on an installation of [Java](https://en.wikipedia.org/wiki/Java_(software_platform)) in order to work.  There are no current or future plans to support Java on Posit Workbench.  Alternative packages such as `{openxlsx}` that do not rely on Java should be used instead.
 
+#### What should I do if I encounter a 'failed to lock directory' error?
+If you are trying to install an R package and see an error message in the console regarding locked directories (e.g. something like `00LOCK` or `failed to lock directory`), try using the `--no-lock` option with `install.packages()` as follows:
+
+```R
+install.packages("<pkg>", INSTALL_opts = "--no-lock")
+```
 
 #### Why does the `{rmapshaper}` package not install?
 


### PR DESCRIPTION
Update FAQs to include guidance on 'failed to lock directory' errors in Posit Workbench.

**Issue Number**: Closes #88 

**Type**: Documentation 

## Description of the Change

Text added to FAQs.md with a code chunk showing suggested code for users to try.

### Verification Process

Code has been widely shared among colleagues and is known to work in most cases.

## Release Notes

Guidance and suggested code added for users in the event of encountering a 'failed to lock directory' error in Posit Workbench when attempting to install packages.

