### PR TITLE
Update How to Install and Use Geospatial R Packages.md to fix bug wit…

### DIFF
--- a/Posit Infrastructure/How to Install and Use Geospatial R Packages.md
+++ b/Posit Infrastructure/How to Install and Use Geospatial R Packages.md
@@ -148,8 +148,8 @@ install.packages("https://ppm.publichealthscotland.org/all-r/latest/src/contrib/
                  Ncpus = ncpus)
 
 # Install the {leaflet} package
-install.packages("leaflet",
-                 repos = c("https://ppm.publichealthscotland.org/all-r/__linux__/centos7/latest"),
+install.packages("https://ppm.publichealthscotland.org/all-r/latest/src/contrib/Archive/leaflet/leaflet_2.1.0.tar.gz",
+                 repos = NULL,
                  type = "source",
                  dependencies = FALSE,
                  configure.args = geo_config_args,


### PR DESCRIPTION
# Pull Request Details

**Issue Number**: Closes #99 

**Type**: Bug; Documentation

## Description of the Change

Amended existing code for installing geospatial packages to point towards {leaflet} v1.2.0. 

### Verification Process

This was tested with both affected colleagues and resolved the issue.

### Additional Work Required

Monitor going forward in case further compatibility issues arise.

## Release Notes

Amended existing code for installing geospatial packages to point towards {leaflet} v1.2.0 due to compatibility issues with {raster} that were preventing Shiny apps from being deployed by several colleagues. 

