### PR TITLE
Amend advice on auto closing RStudio Pro session

### DIFF
--- a/Posit Infrastructure/Best Practice with R in Posit Workbench.md
+++ b/Posit Infrastructure/Best Practice with R in Posit Workbench.md
@@ -211,15 +211,24 @@ g2 <- ggplot(data = iris_areas, mapping = aes(x = Sepal.Area)) +
 grid.arrange(g1, g2, nrow = 2)
 ```
 
-### Automatically close an R session
+### Automatically close an RStudio Pro session
 
-If you want your script to end the session automatically when it completes all its tasks, then include the `q()` or `quit()` function in your script. Both functions perform the same task of terminating the current session.
-
-The first argument, `save`, specifies whether the current environment should be saved. The default behaviour will often ask you interactively, which means it won't automatically close by itself. As discussed earlier, it's considered best practice to never save your environment, so we should pre-emptively tell it not to save the workspace variables:
+If you want your script to end your RStudio Pro session automatically when it completes all of its tasks, then the following code snippet will reliably close the session, even if you have closed your web browser.
 
 ```r
-quit(save = "no")
+# Get the Process ID of the R session
+ppid <- system(paste("ps -o ppid= -p", Sys.getpid()), intern = TRUE)
+# Gracefully terminate the R session
+system(paste("kill -15", ppid))
 ```
+
+On the Posit Workbench homepage, the RStudio Pro session will report that the session is `Executing` whilst R code continues to run:
+
+_screenshot to be inserted here_
+
+On completion, and once the session has closed successfully, the session will be reported as having `Finished`:
+
+_screenshot to be inserted here_
 
 ## Importing and exporting data
 


### PR DESCRIPTION
Involves killing the parent rsession process.

Screenshots to be added at a later date.


